### PR TITLE
Added in a read_multi() function for Rails 3 users

### DIFF
--- a/.rvmrc
+++ b/.rvmrc
@@ -1,0 +1,5 @@
+if [[ -n "$rvm_environments_path" && -s "$rvm_environments_path/ruby-1.9.2-p136@mongo_store" ]] ; then
+  \. "$rvm_environments_path/ruby-1.9.2-p136@mongo_store"
+else
+  rvm --create use  "ruby-1.9.2-p136@mongo_store"
+fi

--- a/History.markdown
+++ b/History.markdown
@@ -1,3 +1,7 @@
+0.3.1 / 2011-03-17
+==================
+  * Added in an optimised 'read_multi' function for Rails 3 - performs a single db call rather than one for each key
+
 0.3.0 / 2010-08-30 
 ==================
   * We have a History file now

--- a/Rakefile
+++ b/Rakefile
@@ -22,22 +22,6 @@ rescue LoadError
   puts "Jeweler (or a dependency) not available. Install it with: gem install jeweler"
 end
 
-require 'spec/rake/spectask'
-Spec::Rake::SpecTask.new(:spec) do |spec|
-  spec.libs << 'lib' << 'spec'
-  spec.spec_files = FileList['spec/**/*_spec.rb']
-end
-
-Spec::Rake::SpecTask.new(:rcov) do |spec|
-  spec.libs << 'lib' << 'spec'
-  spec.pattern = 'spec/**/*_spec.rb'
-  spec.rcov = true
-end
-
-task :spec => :check_dependencies
-
-task :default => :spec
-
 require 'rake/rdoctask'
 Rake::RDocTask.new do |rdoc|
   version = File.exist?('VERSION') ? File.read('VERSION') : ""

--- a/lib/active_support/cache/mongo_store.rb
+++ b/lib/active_support/cache/mongo_store.rb
@@ -87,15 +87,16 @@ module MongoStore
       
       def read_multi(*keys)
         docs   = {}
-        cursor = collection.find('_id' => {'$in' => keys}, 'expires' => {'$gt' => Time.now})
-        
         keys.each do |key|
           docs[key] = nil
         end
         
-        cursor.each do |doc|
-          docs[ doc['_id'] ] = doc['value']
+        collection.find({ '_id' => {'$in' => keys}, 'expires' => {'$gt' => Time.now} }, :timeout => false ) do |cursor|
+          cursor.each do |doc|
+            docs[ doc['_id'] ] = doc['value']
+          end
         end
+        
         return docs
       end
       

--- a/lib/active_support/cache/mongo_store.rb
+++ b/lib/active_support/cache/mongo_store.rb
@@ -24,7 +24,7 @@ module MongoStore
           doc['value']
         end
       end
-        
+      
       # Takes the specified value out of the collection.
       def delete(key, local_options=nil)
         super
@@ -32,44 +32,43 @@ module MongoStore
         collection.remove({'_id' => namespaced_key(key,opts)})
       end
       
-
       # Takes the value matching the pattern out of the collection.
       def delete_matched(key, local_options=nil)
         super
         opts = local_options ? options.merge(local_options) : options
         collection.remove({'_id' => key_matcher(key,opts)})
       end
-
-            
-      protected
-
-      # Lifted from Rails 3 ActiveSupport::Cache::Store
-      def namespaced_key(key, options)
-        namespace = options[:namespace] if options
-        prefix = namespace.is_a?(Proc) ? namespace.call : namespace
-        key = "#{prefix}:#{key}" if prefix
-        key
-      end
       
-      # Lifted from Rails 3 ActiveSupport::Cache::Store
-      def key_matcher(pattern, options)
-        prefix = options[:namespace].is_a?(Proc) ? options[:namespace].call : options[:namespace]
-        if prefix
-          source = pattern.source
-          if source.start_with?('^')
-            source = source[1, source.length]
-          else
-            source = ".*#{source[0, source.length]}"
-          end
-          Regexp.new("^#{Regexp.escape(prefix)}:#{source}", pattern.options)
-        else
-          pattern
+      protected
+        
+        # Lifted from Rails 3 ActiveSupport::Cache::Store
+        def namespaced_key(key, options)
+          namespace = options[:namespace] if options
+          prefix = namespace.is_a?(Proc) ? namespace.call : namespace
+          key = "#{prefix}:#{key}" if prefix
+          key
         end
-      end
+        
+        # Lifted from Rails 3 ActiveSupport::Cache::Store
+        def key_matcher(pattern, options)
+          prefix = options[:namespace].is_a?(Proc) ? options[:namespace].call : options[:namespace]
+          if prefix
+            source = pattern.source
+            if source.start_with?('^')
+              source = source[1, source.length]
+            else
+              source = ".*#{source[0, source.length]}"
+            end
+            Regexp.new("^#{Regexp.escape(prefix)}:#{source}", pattern.options)
+          else
+            pattern
+          end
+        end
       
     end
     
     module Rails3
+      
       def write_entry(key, entry, options)
         expires = Time.now + options[:expires_in]
         value = entry.value
@@ -94,6 +93,7 @@ module MongoStore
           delete_entry(matcher, options) 
         end
       end
+      
     end
     
     module Store
@@ -154,7 +154,7 @@ module ActiveSupport
       def collection
         @collection ||= make_collection
       end
-            
+      
       # Removes old cached values that have expired.  Set this up to run occasionally in delayed_job, etc., if you
       # start worrying about space.  (In practice, because we favor updating over inserting, space is only wasted
       # if the key itself never gets cached again.  It also means you can _reduce_ efficiency by running this
@@ -169,25 +169,26 @@ module ActiveSupport
       end
       
       private
-      def mongomapper?
-        Kernel.const_defined?(:MongoMapper) && MongoMapper.respond_to?(:database) && MongoMapper.database
-      end
-      
-      def make_collection
-        db = case options[:db]
-        when Mongo::DB then options[:db]
-        when String then Mongo::DB.new(options[:db], Mongo::Connection.new)
-        else
-          if mongomapper?
-            MongoMapper.database
-          else
-            Mongo::DB.new(options[:db_name], Mongo::Connection.new)
-          end
+        
+        def mongomapper?
+          Kernel.const_defined?(:MongoMapper) && MongoMapper.respond_to?(:database) && MongoMapper.database
         end
-        coll = db.create_collection(options[:collection_name])
-        coll.create_index([['_id',Mongo::ASCENDING], ['expires',Mongo::DESCENDING]]) if options[:create_index]
-        coll
-      end
+        
+        def make_collection
+          db = case options[:db]
+          when Mongo::DB then options[:db]
+          when String then Mongo::DB.new(options[:db], Mongo::Connection.new)
+          else
+            if mongomapper?
+              MongoMapper.database
+            else
+              Mongo::DB.new(options[:db_name], Mongo::Connection.new)
+            end
+          end
+          coll = db.create_collection(options[:collection_name])
+          coll.create_index([['_id',Mongo::ASCENDING], ['expires',Mongo::DESCENDING]]) if options[:create_index]
+          coll
+        end
         
     end
   end

--- a/mongo_store.gemspec
+++ b/mongo_store.gemspec
@@ -5,7 +5,7 @@
 
 Gem::Specification.new do |s|
   s.name = %q{mongo_store}
-  s.version = "0.3.0"
+  s.version = "0.3.1"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Stephen Eley"]

--- a/spec/active_support/cache/mongo_store_spec.rb
+++ b/spec/active_support/cache/mongo_store_spec.rb
@@ -111,6 +111,13 @@ module ActiveSupport
           @store.read('yoo').should == 'yar'
         end
         
+        it "can read multiple values" do
+          @store.collection.insert({'_id' => 'multi1', :value => 'weee', :expires => (Time.now + 10)})
+          @store.collection.insert({'_id' => 'multi2', :value => 'wooo', :expires => (Time.now + 10)})
+          @store.read_multi('multi1','multi2').should == { 'multi1' => 'weee', 'multi2' => 'wooo' }
+          @store.read_multi('multi1','multi2','multi3').should == { 'multi1' => 'weee', 'multi2' => 'wooo', 'multi3' => nil }
+        end
+        
         it "can delete keys" do
           @store.write('foo', 'bar')
           @store.read('foo').should == 'bar'


### PR DESCRIPTION
Hi,

I've been using your gem (which is great - thanks for putting it together) for a little while and added in this slight optimisation for the read_multi function.

By default ActiveSupport::Cache::Store will just call read_entry() multiple times - thus making many requests to the database, this new function wraps it all up into a single request so will reduce load on the database and should also make requests for multiple objects from the cache faster.

Hope you like the addition, let me know if there are any problems or you can suggest any improvements/changes.

Thanks,

Daz
